### PR TITLE
fix: Update Bintray package name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,7 +138,7 @@ publishing {
     repositories {
         maven {
             // publish=1 automatically publishes the version
-            url = uri("https://api.bintray.com/maven/relaycorp/maven/relaynet-cogrpc/;publish=1")
+            url = uri("https://api.bintray.com/maven/relaycorp/maven/tech.relaycorp.cogrpc/;publish=1")
             credentials {
                 username = System.getenv("BINTRAY_USERNAME")
                 password = System.getenv("BINTRAY_KEY")


### PR DESCRIPTION
I didn't realise the original name on Bintray would cause issues in
JCenter, since people wouldn't be able to find it by that name -- We
have to use the fully-qualified name.

https://bintray.com/relaycorp/maven/tech.relaycorp.cogrpc
