### PR TITLE
fix: Make implementation agnostic of any specific gRPC channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Kotlin JVM library implementing the [Relaynet CogRPC binding](https://specs.rela
 
 To use this library on Android, use the OkHTTP channel integration in [`relaynet-cogrpc-jvm-okhttp`](https://github.com/relaycorp/relaynet-cogrpc-jvm-okhttp).
 
-We don't have a ready-made integration for Netty at this point, but passing the following `ChannelBuilderProvider` to `CogRPCClient()` _should_ work:
+We don't have a ready-made integration for Netty at this point, but passing the following `ChannelBuilderProvider` to `CogRPCClient.Builder.build()` _should_ work:
 
 ```kotlin
 import io.grpc.netty.GrpcSslContexts

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 Kotlin JVM library implementing the [Relaynet CogRPC binding](https://specs.relaynet.link/RS-008).
 
+## gRPC Channel Support
+
+To use this library on Android, use the OkHTTP channel integration in [`relaynet-cogrpc-jvm-okhttp`](https://github.com/relaycorp/relaynet-cogrpc-jvm-okhttp).
+
+We don't have a ready-made integration for Netty at this point, but passing the following `ChannelBuilderProvider` to `CogRPCClient()` _should_ work:
+
+```kotlin
+import io.grpc.netty.GrpcSslContexts
+import io.grpc.netty.NettyChannelBuilder
+
+fun makeSSLContext(trustManager: PrivateSubnetTrustManager) =
+    GrpcSslContexts.forClient().trustManager(trustManager).build()
+
+val provider : ChannelBuilderProvider<NettyChannelBuilder> = { address, trustManager ->
+    NettyChannelBuilder.forAddress(address)
+        .let { if (trustManager) it.sslContext(makeSSLContext(trustManager)) else it }
+}
+```
+
 ## Development
 
 This project uses [Gradle](https://gradle.org/), so the only system dependency is a Java JDK. To install the project along with its dependencies, run `./gradlew build` (or `gradlew.bat build` on Windows).

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 
   // gRPC
   implementation "io.grpc:grpc-netty:$grpcVersion"
+  implementation "io.grpc:grpc-okhttp:$grpcVersion"
   implementation "io.grpc:grpc-protobuf:$grpcVersion"
   implementation "io.grpc:grpc-stub:$grpcVersion"
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,6 @@ dependencies {
   implementation "com.google.protobuf:protobuf-java-util:$protobufVersion"
 
   // gRPC
-  implementation "io.grpc:grpc-okhttp:$grpcVersion"
   implementation "io.grpc:grpc-protobuf:$grpcVersion"
   implementation "io.grpc:grpc-stub:$grpcVersion"
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,6 @@ dependencies {
   implementation "com.google.protobuf:protobuf-java-util:$protobufVersion"
 
   // gRPC
-  implementation "io.grpc:grpc-netty:$grpcVersion"
   implementation "io.grpc:grpc-okhttp:$grpcVersion"
   implementation "io.grpc:grpc-protobuf:$grpcVersion"
   implementation "io.grpc:grpc-stub:$grpcVersion"
@@ -60,6 +59,7 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter:5.6.2"
   testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"
   testImplementation "io.grpc:grpc-testing:$grpcVersion"
+  testImplementation "io.grpc:grpc-netty:$grpcVersion"
   testImplementation "io.netty:netty-tcnative-boringssl-static:2.0.31.Final"
   testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
   testImplementation "org.mockito:mockito-inline:3.5.5"

--- a/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/ChannelBuilderProvider.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/ChannelBuilderProvider.kt
@@ -1,0 +1,9 @@
+package tech.relaycorp.relaynet.cogrpc.client
+
+import io.grpc.ManagedChannelBuilder
+import java.net.InetSocketAddress
+
+typealias ChannelBuilderProvider<T> = (
+    address: InetSocketAddress,
+    privateSubsetTrustManager: PrivateSubnetTrustManager?
+) -> ManagedChannelBuilder<T>

--- a/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/ChannelBuilderProvider.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/ChannelBuilderProvider.kt
@@ -5,5 +5,5 @@ import java.net.InetSocketAddress
 
 typealias ChannelBuilderProvider<T> = (
     address: InetSocketAddress,
-    privateSubsetTrustManager: PrivateSubnetTrustManager?
+    privateSubnetTrustManager: PrivateSubnetTrustManager?
 ) -> ManagedChannelBuilder<T>

--- a/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClient.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClient.kt
@@ -30,7 +30,8 @@ import java.util.logging.Level
 import java.util.logging.Logger
 import kotlin.time.seconds
 
-open class CogRPCClient(
+open class CogRPCClient
+internal constructor(
     serverAddress: String,
     val channelBuilderProvider: ChannelBuilderProvider<*>,
     val requireTls: Boolean = true
@@ -162,6 +163,14 @@ open class CogRPCClient(
         Exception(message, throwable)
 
     class CCARefusedException : CogRPCException()
+
+    object Builder {
+        fun build(
+            serverAddress: String,
+            channelBuilderProvider: ChannelBuilderProvider<*>,
+            requireTls: Boolean = true
+        ) = CogRPCClient(serverAddress, channelBuilderProvider, requireTls)
+    }
 
     companion object {
         internal val logger = Logger.getLogger(CogRPCClient::class.java.name)

--- a/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClient.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClient.kt
@@ -31,10 +31,10 @@ import java.util.logging.Logger
 import kotlin.time.seconds
 
 open class CogRPCClient
-internal constructor(
+private constructor(
     serverAddress: String,
     val channelBuilderProvider: ChannelBuilderProvider<*>,
-    val requireTls: Boolean = true
+    val requireTls: Boolean
 ) {
     private val serverUrl = URL(serverAddress)
 

--- a/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClient.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClient.kt
@@ -55,10 +55,10 @@ private constructor(
     internal val channel by lazy {
         val useTls = requireTls || serverUrl.protocol == "https"
         val isHostPrivateAddress = InetAddress.getByName(serverUrl.host).isSiteLocalAddress
-        val privateSubsetTrustManager =
+        val privateSubnetTrustManager =
             if (useTls && isHostPrivateAddress) PrivateSubnetTrustManager.INSTANCE else null
         channelBuilderProvider
-            .invoke(address, privateSubsetTrustManager)
+            .invoke(address, privateSubnetTrustManager)
             .run { if (useTls) useTransportSecurity() else usePlaintext() }
             .build()
     }

--- a/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManager.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManager.kt
@@ -52,6 +52,5 @@ class PrivateSubnetTrustManager private constructor() : X509ExtendedTrustManager
         val INSTANCE = PrivateSubnetTrustManager()
         private val clientValidationNotImplementedError =
             NotImplementedError("Client-side certificate validation is unsupported")
-
     }
 }

--- a/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManager.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManager.kt
@@ -14,6 +14,7 @@ class PrivateSubnetTrustManager private constructor() : X509TrustManager {
     override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
         // We don't really care about the validity of the certificate, but we can't leave this
         // method implementation empty because Android would refuse it.
+        chain?.map { it.checkValidity() }
     }
 
     override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()

--- a/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManager.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManager.kt
@@ -12,6 +12,8 @@ class PrivateSubnetTrustManager private constructor() : X509TrustManager {
     }
 
     override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+        // We don't really care about the validity of the certificate, but we can't leave this
+        // method implementation empty because Android would refuse it.
     }
 
     override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()

--- a/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManager.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManager.kt
@@ -1,0 +1,57 @@
+package tech.relaycorp.relaynet.cogrpc.client
+
+import java.net.Socket
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.X509ExtendedTrustManager
+
+/**
+ * Trust manager that accepts self-issued certificates in a private subnet.
+ */
+class PrivateSubnetTrustManager private constructor() : X509ExtendedTrustManager() {
+    override fun checkClientTrusted(
+        chain: Array<out X509Certificate>?,
+        authType: String?,
+        socket: Socket?
+    ) {
+        throw clientValidationNotImplementedError
+    }
+
+    override fun checkClientTrusted(
+        chain: Array<out X509Certificate>?,
+        authType: String?,
+        engine: SSLEngine?
+    ) {
+        throw clientValidationNotImplementedError
+    }
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+        throw clientValidationNotImplementedError
+    }
+
+    override fun checkServerTrusted(
+        chain: Array<out X509Certificate>?,
+        authType: String?,
+        socket: Socket?
+    ) {
+    }
+
+    override fun checkServerTrusted(
+        chain: Array<out X509Certificate>?,
+        authType: String?,
+        engine: SSLEngine?
+    ) {
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+
+    companion object {
+        val INSTANCE = PrivateSubnetTrustManager()
+        private val clientValidationNotImplementedError =
+            NotImplementedError("Client-side certificate validation is unsupported")
+
+    }
+}

--- a/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManager.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManager.kt
@@ -1,46 +1,14 @@
 package tech.relaycorp.relaynet.cogrpc.client
 
-import java.net.Socket
 import java.security.cert.X509Certificate
-import javax.net.ssl.SSLEngine
-import javax.net.ssl.X509ExtendedTrustManager
+import javax.net.ssl.X509TrustManager
 
 /**
  * Trust manager that accepts self-issued certificates in a private subnet.
  */
-class PrivateSubnetTrustManager private constructor() : X509ExtendedTrustManager() {
-    override fun checkClientTrusted(
-        chain: Array<out X509Certificate>?,
-        authType: String?,
-        socket: Socket?
-    ) {
-        throw clientValidationNotImplementedError
-    }
-
-    override fun checkClientTrusted(
-        chain: Array<out X509Certificate>?,
-        authType: String?,
-        engine: SSLEngine?
-    ) {
-        throw clientValidationNotImplementedError
-    }
-
+class PrivateSubnetTrustManager private constructor() : X509TrustManager {
     override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
-        throw clientValidationNotImplementedError
-    }
-
-    override fun checkServerTrusted(
-        chain: Array<out X509Certificate>?,
-        authType: String?,
-        socket: Socket?
-    ) {
-    }
-
-    override fun checkServerTrusted(
-        chain: Array<out X509Certificate>?,
-        authType: String?,
-        engine: SSLEngine?
-    ) {
+        throw NotImplementedError("Client-side certificate validation is unsupported")
     }
 
     override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
@@ -50,7 +18,5 @@ class PrivateSubnetTrustManager private constructor() : X509ExtendedTrustManager
 
     companion object {
         val INSTANCE = PrivateSubnetTrustManager()
-        private val clientValidationNotImplementedError =
-            NotImplementedError("Client-side certificate validation is unsupported")
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientBuildTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientBuildTest.kt
@@ -15,16 +15,16 @@ import java.net.MalformedURLException
 
 class CogRPCClientBuildTest {
     private lateinit var spiedChannelBuilder: NettyChannelBuilder
-    private var privateSubsetTrustManager: PrivateSubnetTrustManager? = null
+    private var privateSubnetTrustManager: PrivateSubnetTrustManager? = null
     private val channelBuilderProvider: ChannelBuilderProvider<NettyChannelBuilder> = { addr, tm ->
-        privateSubsetTrustManager = tm
+        privateSubnetTrustManager = tm
         spiedChannelBuilder = spy(NettyChannelBuilder.forAddress(addr))
         spiedChannelBuilder
     }
 
     @BeforeEach
     internal fun setUp() {
-        privateSubsetTrustManager = null
+        privateSubnetTrustManager = null
     }
 
     @Test
@@ -95,7 +95,7 @@ class CogRPCClientBuildTest {
 
         assertTrue(spiedClient.channel is ManagedChannel)
         verify(spiedChannelBuilder, never()).usePlaintext()
-        assertNull(privateSubsetTrustManager)
+        assertNull(privateSubnetTrustManager)
     }
 
     @Test
@@ -107,7 +107,7 @@ class CogRPCClientBuildTest {
 
         assertTrue(spiedClient.channel is ManagedChannel)
         verify(spiedChannelBuilder, never()).usePlaintext()
-        assertEquals(PrivateSubnetTrustManager.INSTANCE, privateSubsetTrustManager)
+        assertEquals(PrivateSubnetTrustManager.INSTANCE, privateSubnetTrustManager)
     }
 
     @Test
@@ -118,6 +118,6 @@ class CogRPCClientBuildTest {
 
         assertTrue(spiedClient.channel is ManagedChannel)
         verify(spiedChannelBuilder).usePlaintext()
-        assertNull(privateSubsetTrustManager)
+        assertNull(privateSubnetTrustManager)
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientBuildTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientBuildTest.kt
@@ -1,71 +1,72 @@
 package tech.relaycorp.relaynet.cogrpc.client
 
-import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
 import io.grpc.ManagedChannel
-import io.grpc.okhttp.OkHttpChannelBuilder
+import io.grpc.netty.NettyChannelBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.net.InetSocketAddress
 import java.net.MalformedURLException
 
 class CogRPCClientBuildTest {
-    private lateinit var spiedChannelBuilder: OkHttpChannelBuilder
-    private lateinit var spiedChannelBuilderProvider: (InetSocketAddress) -> OkHttpChannelBuilder
+    private lateinit var spiedChannelBuilder: NettyChannelBuilder
+    private var privateSubsetTrustManager: PrivateSubnetTrustManager? = null
+    private val channelBuilderProvider: ChannelBuilderProvider<NettyChannelBuilder> = { addr, tm ->
+        privateSubsetTrustManager = tm
+        spiedChannelBuilder = spy(NettyChannelBuilder.forAddress(addr))
+        spiedChannelBuilder
+    }
 
     @BeforeEach
     internal fun setUp() {
-        spiedChannelBuilder = spy(OkHttpChannelBuilder.forAddress("127.0.0.1", 80))
-        spiedChannelBuilderProvider = { spiedChannelBuilder }
+        privateSubsetTrustManager = null
     }
 
     @Test
-    internal fun `invalid address throws exception`() {
-        assertThrows<MalformedURLException> { CogRPCClient.Builder.build("invalid") }
+    fun `invalid address throws exception`() {
+        assertThrows<MalformedURLException> { CogRPCClient("invalid", channelBuilderProvider) }
     }
 
     @Test
-    internal fun `TLS is required by default`() {
-        val client = CogRPCClient.Builder.build("https://example.org")
+    fun `TLS is required by default`() {
+        val client = CogRPCClient("https://example.org", channelBuilderProvider)
         assertTrue(client.requireTls)
     }
 
     @Test
-    internal fun `HTTPS URL defaults to port 443`() {
-        val client = CogRPCClient.Builder.build("https://example.org")
+    fun `HTTPS URL defaults to port 443`() {
+        val client = CogRPCClient("https://example.org", channelBuilderProvider)
 
         assertEquals("example.org:443", client.channel.authority())
     }
 
     @Test
-    internal fun `HTTP URL with TLS required should throw an exception`() {
+    fun `HTTP URL with TLS required should throw an exception`() {
         val serverAddress = "http://example.com"
         val exception =
             assertThrows<CogRPCClient.CogRPCException> {
-                CogRPCClient.Builder.build(
-                    serverAddress
-                )
+                CogRPCClient(serverAddress, channelBuilderProvider)
             }
 
         assertEquals("Cannot connect to $serverAddress with TLS required", exception.message)
     }
 
     @Test
-    internal fun `HTTP URL defaults to port 80`() {
-        val client = CogRPCClient.Builder.build("http://example.org", false)
+    fun `HTTP URL defaults to port 80`() {
+        val client = CogRPCClient("http://example.org", channelBuilderProvider, false)
 
         assertEquals("example.org:80", client.channel.authority())
     }
 
     @Test
-    internal fun `Channel should use TLS if URL is HTTPS`() {
+    fun `Channel should use TLS if URL is HTTPS`() {
         val spiedClient = spy(
-            CogRPCClient("https://1.1.1.1", true, spiedChannelBuilderProvider)
+            CogRPCClient("https://1.1.1.1", channelBuilderProvider, true)
         )
 
         assertTrue(spiedClient.channel is ManagedChannel)
@@ -73,9 +74,9 @@ class CogRPCClientBuildTest {
     }
 
     @Test
-    internal fun `Channel should use TLS if TLS is not required but URL is HTTPS`() {
+    fun `Channel should use TLS if TLS is not required but URL is HTTPS`() {
         val spiedClient = spy(
-            CogRPCClient("https://1.1.1.1", false, spiedChannelBuilderProvider)
+            CogRPCClient("https://1.1.1.1", channelBuilderProvider, false)
         )
 
         assertTrue(spiedClient.channel is ManagedChannel)
@@ -84,36 +85,36 @@ class CogRPCClientBuildTest {
     }
 
     @Test
-    internal fun `TLS server certificate should be validated if host is not private IP`() {
+    fun `TLS server certificate should be validated if host is not private IP`() {
         val spiedClient = spy(
-            CogRPCClient("https://1.1.1.1", true, spiedChannelBuilderProvider)
+            CogRPCClient("https://1.1.1.1", channelBuilderProvider, true)
         )
 
         assertTrue(spiedClient.channel is ManagedChannel)
         verify(spiedChannelBuilder, never()).usePlaintext()
-        verify(spiedChannelBuilder, never()).sslSocketFactory(any())
+        assertNull(privateSubsetTrustManager)
     }
 
     @Test
     fun `TLS server certificate should not be validated if host is private IP`() {
         val hostName = "192.168.43.1"
         val spiedClient = spy(
-            CogRPCClient("https://$hostName", true, spiedChannelBuilderProvider)
+            CogRPCClient("https://$hostName", channelBuilderProvider, true)
         )
 
         assertTrue(spiedClient.channel is ManagedChannel)
         verify(spiedChannelBuilder, never()).usePlaintext()
-        verify(spiedChannelBuilder).overrideAuthority("$hostName:443")
+        assertEquals(PrivateSubnetTrustManager.INSTANCE, privateSubsetTrustManager)
     }
 
     @Test
-    internal fun `TLS should not be used if URL is HTTP`() {
+    fun `TLS should not be used if URL is HTTP`() {
         val spiedClient = spy(
-            CogRPCClient("http://192.168.43.1", false, spiedChannelBuilderProvider)
+            CogRPCClient("http://192.168.43.1", channelBuilderProvider, false)
         )
 
         assertTrue(spiedClient.channel is ManagedChannel)
         verify(spiedChannelBuilder).usePlaintext()
-        verify(spiedChannelBuilder, never()).sslSocketFactory(any())
+        assertNull(privateSubsetTrustManager)
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientBuildTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientBuildTest.kt
@@ -95,14 +95,15 @@ class CogRPCClientBuildTest {
     }
 
     @Test
-    internal fun `TLS server certificate should not be validated if host is private IP`() {
+    fun `TLS server certificate should not be validated if host is private IP`() {
+        val hostName = "192.168.43.1"
         val spiedClient = spy(
-            CogRPCClient("https://192.168.43.1", true, spiedChannelBuilderProvider)
+            CogRPCClient("https://$hostName", true, spiedChannelBuilderProvider)
         )
 
         assertTrue(spiedClient.channel is ManagedChannel)
         verify(spiedChannelBuilder, never()).usePlaintext()
-        verify(spiedChannelBuilder).sslSocketFactory(spiedClient.insecureSocketFactory)
+        verify(spiedChannelBuilder).overrideAuthority("$hostName:443")
     }
 
     @Test

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientBuildTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientBuildTest.kt
@@ -29,18 +29,20 @@ class CogRPCClientBuildTest {
 
     @Test
     fun `invalid address throws exception`() {
-        assertThrows<MalformedURLException> { CogRPCClient("invalid", channelBuilderProvider) }
+        assertThrows<MalformedURLException> {
+            CogRPCClient.Builder.build("invalid", channelBuilderProvider)
+        }
     }
 
     @Test
     fun `TLS is required by default`() {
-        val client = CogRPCClient("https://example.org", channelBuilderProvider)
+        val client = CogRPCClient.Builder.build("https://example.org", channelBuilderProvider)
         assertTrue(client.requireTls)
     }
 
     @Test
     fun `HTTPS URL defaults to port 443`() {
-        val client = CogRPCClient("https://example.org", channelBuilderProvider)
+        val client = CogRPCClient.Builder.build("https://example.org", channelBuilderProvider)
 
         assertEquals("example.org:443", client.channel.authority())
     }
@@ -50,7 +52,7 @@ class CogRPCClientBuildTest {
         val serverAddress = "http://example.com"
         val exception =
             assertThrows<CogRPCClient.CogRPCException> {
-                CogRPCClient(serverAddress, channelBuilderProvider)
+                CogRPCClient.Builder.build(serverAddress, channelBuilderProvider)
             }
 
         assertEquals("Cannot connect to $serverAddress with TLS required", exception.message)
@@ -58,7 +60,8 @@ class CogRPCClientBuildTest {
 
     @Test
     fun `HTTP URL defaults to port 80`() {
-        val client = CogRPCClient("http://example.org", channelBuilderProvider, false)
+        val client =
+            CogRPCClient.Builder.build("http://example.org", channelBuilderProvider, false)
 
         assertEquals("example.org:80", client.channel.authority())
     }
@@ -66,7 +69,7 @@ class CogRPCClientBuildTest {
     @Test
     fun `Channel should use TLS if URL is HTTPS`() {
         val spiedClient = spy(
-            CogRPCClient("https://1.1.1.1", channelBuilderProvider, true)
+            CogRPCClient.Builder.build("https://1.1.1.1", channelBuilderProvider, true)
         )
 
         assertTrue(spiedClient.channel is ManagedChannel)
@@ -76,7 +79,7 @@ class CogRPCClientBuildTest {
     @Test
     fun `Channel should use TLS if TLS is not required but URL is HTTPS`() {
         val spiedClient = spy(
-            CogRPCClient("https://1.1.1.1", channelBuilderProvider, false)
+            CogRPCClient.Builder.build("https://1.1.1.1", channelBuilderProvider, false)
         )
 
         assertTrue(spiedClient.channel is ManagedChannel)
@@ -87,7 +90,7 @@ class CogRPCClientBuildTest {
     @Test
     fun `TLS server certificate should be validated if host is not private IP`() {
         val spiedClient = spy(
-            CogRPCClient("https://1.1.1.1", channelBuilderProvider, true)
+            CogRPCClient.Builder.build("https://1.1.1.1", channelBuilderProvider, true)
         )
 
         assertTrue(spiedClient.channel is ManagedChannel)
@@ -99,7 +102,7 @@ class CogRPCClientBuildTest {
     fun `TLS server certificate should not be validated if host is private IP`() {
         val hostName = "192.168.43.1"
         val spiedClient = spy(
-            CogRPCClient("https://$hostName", channelBuilderProvider, true)
+            CogRPCClient.Builder.build("https://$hostName", channelBuilderProvider, true)
         )
 
         assertTrue(spiedClient.channel is ManagedChannel)
@@ -110,7 +113,7 @@ class CogRPCClientBuildTest {
     @Test
     fun `TLS should not be used if URL is HTTP`() {
         val spiedClient = spy(
-            CogRPCClient("http://192.168.43.1", channelBuilderProvider, false)
+            CogRPCClient.Builder.build("http://192.168.43.1", channelBuilderProvider, false)
         )
 
         assertTrue(spiedClient.channel is ManagedChannel)

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientBuildTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientBuildTest.kt
@@ -5,7 +5,7 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
 import io.grpc.ManagedChannel
-import io.grpc.netty.NettyChannelBuilder
+import io.grpc.okhttp.OkHttpChannelBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -15,12 +15,12 @@ import java.net.InetSocketAddress
 import java.net.MalformedURLException
 
 class CogRPCClientBuildTest {
-    private lateinit var spiedChannelBuilder: NettyChannelBuilder
-    private lateinit var spiedChannelBuilderProvider: (InetSocketAddress) -> NettyChannelBuilder
+    private lateinit var spiedChannelBuilder: OkHttpChannelBuilder
+    private lateinit var spiedChannelBuilderProvider: (InetSocketAddress) -> OkHttpChannelBuilder
 
     @BeforeEach
     internal fun setUp() {
-        spiedChannelBuilder = spy(NettyChannelBuilder.forAddress(InetSocketAddress(80)))
+        spiedChannelBuilder = spy(OkHttpChannelBuilder.forAddress("127.0.0.1", 80))
         spiedChannelBuilderProvider = { spiedChannelBuilder }
     }
 
@@ -91,7 +91,7 @@ class CogRPCClientBuildTest {
 
         assertTrue(spiedClient.channel is ManagedChannel)
         verify(spiedChannelBuilder, never()).usePlaintext()
-        verify(spiedChannelBuilder, never()).sslContext(any())
+        verify(spiedChannelBuilder, never()).sslSocketFactory(any())
     }
 
     @Test
@@ -102,7 +102,7 @@ class CogRPCClientBuildTest {
 
         assertTrue(spiedClient.channel is ManagedChannel)
         verify(spiedChannelBuilder, never()).usePlaintext()
-        verify(spiedChannelBuilder).sslContext(spiedClient.insecureTlsContext)
+        verify(spiedChannelBuilder).sslSocketFactory(spiedClient.insecureSocketFactory)
     }
 
     @Test
@@ -113,6 +113,6 @@ class CogRPCClientBuildTest {
 
         assertTrue(spiedClient.channel is ManagedChannel)
         verify(spiedChannelBuilder).usePlaintext()
-        verify(spiedChannelBuilder, never()).sslContext(any())
+        verify(spiedChannelBuilder, never()).sslSocketFactory(any())
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientTest.kt
@@ -48,7 +48,7 @@ internal class CogRPCClientTest {
         runBlocking {
             val mockServerService = MockCogRPCServerService()
             buildAndStartServer(mockServerService)
-            val client = CogRPCClient(ADDRESS, channelBuilderProvider, false)
+            val client = CogRPCClient.Builder.build(ADDRESS, channelBuilderProvider, false)
             val cargo = buildRequest()
 
             // Server acks and completes instantaneously
@@ -79,7 +79,7 @@ internal class CogRPCClientTest {
         runBlocking {
             val mockServerService = MockCogRPCServerService()
             buildAndStartServer(mockServerService)
-            val client = CogRPCClient(ADDRESS, channelBuilderProvider, false)
+            val client = CogRPCClient.Builder.build(ADDRESS, channelBuilderProvider, false)
             val acks = client.deliverCargo(emptyList()).toList()
 
             assertTrue(acks.isEmpty())
@@ -93,7 +93,7 @@ internal class CogRPCClientTest {
         runBlocking {
             val mockServerService = MockCogRPCServerService()
             buildAndStartServer(mockServerService)
-            val client = CogRPCClient(ADDRESS, channelBuilderProvider, false)
+            val client = CogRPCClient.Builder.build(ADDRESS, channelBuilderProvider, false)
             val cargo = buildRequest()
 
             // Server never acks, just completes
@@ -116,7 +116,7 @@ internal class CogRPCClientTest {
         runBlocking {
             val mockServerService = MockCogRPCServerService()
             buildAndStartServer(mockServerService)
-            val client = CogRPCClient(ADDRESS, channelBuilderProvider, false)
+            val client = CogRPCClient.Builder.build(ADDRESS, channelBuilderProvider, false)
             val cargo = buildRequest()
 
             // Server acks and completes instantaneously
@@ -149,7 +149,7 @@ internal class CogRPCClientTest {
         runBlocking {
             val mockServerService = MockCogRPCServerService()
             buildAndStartServer(mockServerService)
-            val client = CogRPCClient(ADDRESS, channelBuilderProvider, false)
+            val client = CogRPCClient.Builder.build(ADDRESS, channelBuilderProvider, false)
             val ackRecorder = StreamRecorder.create<CargoDeliveryAck>()
             mockServerService.collectCargoReturned = ackRecorder
 
@@ -185,7 +185,7 @@ internal class CogRPCClientTest {
         runBlocking {
             val mockServerService = MockCogRPCServerService()
             buildAndStartServer(mockServerService)
-            val client = CogRPCClient(ADDRESS, channelBuilderProvider, false)
+            val client = CogRPCClient.Builder.build(ADDRESS, channelBuilderProvider, false)
             val ackRecorder = StreamRecorder.create<CargoDeliveryAck>()
             mockServerService.collectCargoReturned = ackRecorder
 
@@ -227,7 +227,7 @@ internal class CogRPCClientTest {
         runBlocking {
             val mockServerService = MockCogRPCServerService()
             buildAndStartServer(mockServerService)
-            val client = CogRPCClient(ADDRESS, channelBuilderProvider, false)
+            val client = CogRPCClient.Builder.build(ADDRESS, channelBuilderProvider, false)
 
             // Client call
             val cca = buildMessageSerialized()
@@ -255,7 +255,7 @@ internal class CogRPCClientTest {
         runBlocking {
             val mockServerService = MockCogRPCServerService()
             buildAndStartServer(mockServerService)
-            val client = CogRPCClient(ADDRESS, channelBuilderProvider, false)
+            val client = CogRPCClient.Builder.build(ADDRESS, channelBuilderProvider, false)
 
             // Client call
             val cca = buildMessageSerialized()
@@ -283,7 +283,7 @@ internal class CogRPCClientTest {
         runBlocking {
             val mockServerService = MockCogRPCServerService()
             buildAndStartServer(mockServerService)
-            val client = CogRPCClient(ADDRESS, channelBuilderProvider, false)
+            val client = CogRPCClient.Builder.build(ADDRESS, channelBuilderProvider, false)
 
             // Client call
             val cca = buildMessageSerialized()

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManagerTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManagerTest.kt
@@ -1,0 +1,56 @@
+package tech.relaycorp.relaynet.cogrpc.client
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.net.Socket
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+
+class PrivateSubnetTrustManagerTest {
+    @Test
+    fun `Client-side certificate validation methods should not be implemented`() {
+        assertThrows(NotImplementedError::class.java) {
+            PrivateSubnetTrustManager.INSTANCE.checkClientTrusted(CERT_CHAIN, null)
+        }
+        assertThrows(NotImplementedError::class.java) {
+            PrivateSubnetTrustManager.INSTANCE.checkClientTrusted(
+                CERT_CHAIN,
+                null,
+                SSL_CONTEXT.createSSLEngine()
+            )
+        }
+        assertThrows(NotImplementedError::class.java) {
+            val socket = Socket()
+            socket.use {
+                PrivateSubnetTrustManager.INSTANCE.checkClientTrusted(CERT_CHAIN, null, socket)
+            }
+        }
+    }
+
+    @Test
+    fun `Server-side certificate validation methods should do nothing`() {
+        PrivateSubnetTrustManager.INSTANCE.checkServerTrusted(CERT_CHAIN, null)
+
+        PrivateSubnetTrustManager.INSTANCE.checkServerTrusted(
+            CERT_CHAIN,
+            null,
+            SSL_CONTEXT.createSSLEngine()
+        )
+
+        val socket = Socket()
+        socket.use {
+            PrivateSubnetTrustManager.INSTANCE.checkServerTrusted(CERT_CHAIN, null, socket)
+        }
+    }
+
+    @Test
+    fun `getAcceptedIssuers should return an empty array`() {
+        assertEquals(0, PrivateSubnetTrustManager.INSTANCE.acceptedIssuers.size)
+    }
+
+    companion object {
+        private val CERT_CHAIN = emptyArray<X509Certificate>()
+        private val SSL_CONTEXT = SSLContext.getDefault()
+    }
+}

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManagerTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManagerTest.kt
@@ -3,9 +3,7 @@ package tech.relaycorp.relaynet.cogrpc.client
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
-import java.net.Socket
 import java.security.cert.X509Certificate
-import javax.net.ssl.SSLContext
 
 class PrivateSubnetTrustManagerTest {
     @Test
@@ -13,35 +11,11 @@ class PrivateSubnetTrustManagerTest {
         assertThrows(NotImplementedError::class.java) {
             PrivateSubnetTrustManager.INSTANCE.checkClientTrusted(CERT_CHAIN, null)
         }
-        assertThrows(NotImplementedError::class.java) {
-            PrivateSubnetTrustManager.INSTANCE.checkClientTrusted(
-                CERT_CHAIN,
-                null,
-                SSL_CONTEXT.createSSLEngine()
-            )
-        }
-        assertThrows(NotImplementedError::class.java) {
-            val socket = Socket()
-            socket.use {
-                PrivateSubnetTrustManager.INSTANCE.checkClientTrusted(CERT_CHAIN, null, socket)
-            }
-        }
     }
 
     @Test
     fun `Server-side certificate validation methods should do nothing`() {
         PrivateSubnetTrustManager.INSTANCE.checkServerTrusted(CERT_CHAIN, null)
-
-        PrivateSubnetTrustManager.INSTANCE.checkServerTrusted(
-            CERT_CHAIN,
-            null,
-            SSL_CONTEXT.createSSLEngine()
-        )
-
-        val socket = Socket()
-        socket.use {
-            PrivateSubnetTrustManager.INSTANCE.checkServerTrusted(CERT_CHAIN, null, socket)
-        }
     }
 
     @Test
@@ -51,6 +25,5 @@ class PrivateSubnetTrustManagerTest {
 
     companion object {
         private val CERT_CHAIN = emptyArray<X509Certificate>()
-        private val SSL_CONTEXT = SSLContext.getDefault()
     }
 }

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManagerTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/PrivateSubnetTrustManagerTest.kt
@@ -1,5 +1,7 @@
 package tech.relaycorp.relaynet.cogrpc.client
 
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -7,15 +9,22 @@ import java.security.cert.X509Certificate
 
 class PrivateSubnetTrustManagerTest {
     @Test
-    fun `Client-side certificate validation methods should not be implemented`() {
+    fun `Client-side certificate validation method should not be implemented`() {
         assertThrows(NotImplementedError::class.java) {
             PrivateSubnetTrustManager.INSTANCE.checkClientTrusted(CERT_CHAIN, null)
         }
     }
 
     @Test
-    fun `Server-side certificate validation methods should do nothing`() {
+    fun `Server-side certificate validation method should not require a chain`() {
+        PrivateSubnetTrustManager.INSTANCE.checkServerTrusted(null, null)
+    }
+
+    @Test
+    fun `Validity period of server-side certificate chain should be validated`() {
         PrivateSubnetTrustManager.INSTANCE.checkServerTrusted(CERT_CHAIN, null)
+
+        verify(CERT).checkValidity()
     }
 
     @Test
@@ -24,6 +33,7 @@ class PrivateSubnetTrustManagerTest {
     }
 
     companion object {
-        private val CERT_CHAIN = emptyArray<X509Certificate>()
+        private val CERT = mock<X509Certificate>()
+        private val CERT_CHAIN = arrayOf(CERT)
     }
 }


### PR DESCRIPTION
So we can use OkHTTP on Android and Netty everywhere else.

See also: https://github.com/relaycorp/relaynet-cogrpc-jvm-okhttp/pull/1

This is needed for https://github.com/relaycorp/relaynet-courier-android/pull/169